### PR TITLE
Add circuit operator and diffusers UNet support

### DIFF
--- a/inverse_configs/circuit_model_config.yaml
+++ b/inverse_configs/circuit_model_config.yaml
@@ -1,0 +1,15 @@
+# Circuit Layout Model Configuration
+image_size: 128
+in_channels: 3
+out_channels: 3
+layers_per_block: 2
+block_out_channels: [128, 256, 256, 512]
+down_block_types: ["DownBlock2D", "DownBlock2D", "AttnDownBlock2D", "DownBlock2D"]
+up_block_types: ["UpBlock2D", "AttnUpBlock2D", "UpBlock2D", "UpBlock2D"]
+learn_sigma: false
+class_cond: false
+use_checkpoint: false
+use_fp16: false
+shape: (3, 128, 128)
+model_dir: models/
+model_name: final_model.pt

--- a/inverse_configs/circuit_simple_config.yaml
+++ b/inverse_configs/circuit_simple_config.yaml
@@ -1,0 +1,13 @@
+parameters:
+  weight_scale: 1e-6
+  lr: 5e-3
+
+data:
+  root: data/circuit/
+
+measurement:
+  operator:
+    name: circuit_simple
+  noise:
+    name: gaussian
+    sigma: 0.05

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 torchvision
 tqdm
 numpy
+diffusers

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -1,3 +1,4 @@
+import os
 from glob import glob
 from PIL import Image
 from typing import Callable, Optional
@@ -56,7 +57,7 @@ class FFHQDataset(VisionDataset):
             img = self.transforms(img)
         
         return img
-    
+
 @register_dataset(name='cifar')
 class CIFARDataset(VisionDataset):
     def __init__(self, root: str, transforms: Optional[Callable]=None):
@@ -74,3 +75,18 @@ class CIFARDataset(VisionDataset):
             img = self.transforms(img)
         
         return img
+
+@register_dataset(name='circuit')
+class CircuitDataset(VisionDataset):
+    def __init__(self, root: str, transforms: Optional[Callable] = None):
+        super().__init__(root, transforms)
+        self.fpaths = sorted(glob(os.path.join(root, '*.jpg')) +
+                             glob(os.path.join(root, '*.png')))
+        assert len(self.fpaths) > 0, "Dataset folder is empty."
+
+    def __len__(self):
+        return len(self.fpaths)
+
+    def __getitem__(self, index: int):
+        img = Image.open(self.fpaths[index]).convert('RGB')
+        return self.transforms(img) if self.transforms else img

--- a/utils/inverse.py
+++ b/utils/inverse.py
@@ -49,7 +49,7 @@ def process(x):
 def parse_args():
     parser = argparse.ArgumentParser(description='Compute DDP on MNIST.')
     parser.add_argument('--task', help='Task to benchmark: box_inpainting / random_inpainting / motion_deblur / gaussian_deblur / super_resolution / phase_retrieval', default='super_resolution', type=str)
-    parser.add_argument('--dataset', help='Dataset: ffhq / imagenet', default='ffhq', type=str)
+    parser.add_argument('--dataset', help='Dataset: ffhq / imagenet / circuit', default='ffhq', type=str)
     parser.add_argument('--num_iters', help='Number of DDP iterations', default=50, type=int)
     parser.add_argument('--num_steps', help='Number of steps of the diffusion process', type=int, default=20)
     parser.add_argument('--seed', help='Random seed, set to -1 if no seed', type=int, default=42)

--- a/utils/unet.py
+++ b/utils/unet.py
@@ -18,6 +18,7 @@ from .nn import (
     normalization,
     timestep_embedding,
 )
+from diffusers import UNet2DModel
 
 
 NUM_CLASSES = 1000
@@ -42,6 +43,24 @@ def create_model(
     model_path='',
     **kwargs,
 ):
+    if 'block_out_channels' in kwargs:
+        model = UNet2DModel(
+            sample_size=image_size,
+            in_channels=kwargs.get('in_channels', 3),
+            out_channels=kwargs.get('out_channels', 3),
+            layers_per_block=kwargs.get('layers_per_block', 2),
+            block_out_channels=kwargs['block_out_channels'],
+            down_block_types=kwargs['down_block_types'],
+            up_block_types=kwargs['up_block_types'],
+        )
+
+        try:
+            state = th.load(model_path, map_location='cpu')
+            model.load_state_dict(state)
+        except Exception as e:
+            print(f"Got exception: {e} / Randomly initialize")
+        return model
+
     if channel_mult == "":
         if image_size == 512:
             channel_mult = (0.5, 1, 1, 2, 2, 4, 4)


### PR DESCRIPTION
## Summary
- add diffusers as dependency and extend `utils/unet.py` to load a `UNet2DModel` when config uses `block_out_channels`
- register new `CircuitDataset` and `CircuitSimpleOperator`
- allow `circuit` dataset option in inverse experiments
- provide circuit model and task configs

## Testing
- `python -m py_compile utils/unet.py`
- `python -m py_compile utils/dataloader.py`
- `python -m py_compile utils/inverse.py`
- `python -m py_compile utils/measurements.py`
- `python inverse_sampling.py --help` *(fails: ModuleNotFoundError: No module named 'lpips')*

------
https://chatgpt.com/codex/tasks/task_e_688070a0909883238bbd6fbe262a793e