### PR TITLE
Allow diffusers configs in create_model

### DIFF
--- a/utils/unet.py
+++ b/utils/unet.py
@@ -25,8 +25,8 @@ NUM_CLASSES = 1000
 
 def create_model(
     image_size,
-    num_channels,
-    num_res_blocks,
+    num_channels=None,
+    num_res_blocks=None,
     channel_mult="",
     learn_sigma=False,
     class_cond=False,
@@ -59,7 +59,10 @@ def create_model(
             model.load_state_dict(state)
         except Exception as e:
             print(f"Got exception: {e} / Randomly initialize")
+
         return model
+
+    assert num_channels is not None and num_res_blocks is not None
 
     if channel_mult == "":
         if image_size == 512:


### PR DESCRIPTION
## Summary
- make `num_channels` and `num_res_blocks` optional for `create_model`
- assert they are provided when creating an internal `UNetModel`
- allow diffusers configs to call `create_model` without passing these args

## Testing
- `pytest -q`
- `python - <<'PY'
from utils.unet import create_model
cfg = {
    'image_size': 128,
    'in_channels': 3,
    'out_channels': 3,
    'layers_per_block': 2,
    'block_out_channels': [128, 256, 256, 512],
    'down_block_types': ["DownBlock2D", "DownBlock2D", "AttnDownBlock2D", "DownBlock2D"],
    'up_block_types': ["UpBlock2D", "AttnUpBlock2D", "UpBlock2D", "UpBlock2D"],
    'model_path': ''
}
create_model(**cfg)
create_model(image_size=64, num_channels=128, num_res_blocks=2, model_path='')
PY

------
https://chatgpt.com/codex/tasks/task_e_688134deeed4832380bbe473507827cd